### PR TITLE
Fix US customary fluid volume unit versions

### DIFF
--- a/src/BuiltIns.js
+++ b/src/BuiltIns.js
@@ -369,7 +369,7 @@ export const units = {
   cuft: '1 ft^3',
   cuyd: '1 yd^3',
   teaspoon: {
-    value: '5 mL',
+    value: '4.92892159375 mL',
     aliases: ['teaspoons', 'tsp']
   },
   tablespoon: {
@@ -385,7 +385,7 @@ export const units = {
     aliases: ['minims']
   },
   fluidounce: {
-    value: '0.00002957353 mL',
+    value: '0.125 cups',
     aliases: ['floz', 'fluidounces']
   },
   fluiddram: {

--- a/test/Unit.test.js
+++ b/test/Unit.test.js
@@ -2376,4 +2376,17 @@ describe('unitmath', () => {
       })
     })
   })
+
+  describe('built-in units', () => {
+    describe('us customary liquid units', () => {
+      assert.strictEqual(unit('1 cup').to('mL').toString(), '236.5882365 mL')
+      assert.strictEqual(unit('1 cup').to('gallons').toString(), '0.0625 gallons')
+      assert.strictEqual(unit('1 cup').to('quarts').toString(), '0.25 quarts')
+      assert.strictEqual(unit('1 cup').to('pints').toString(), '0.5 pints')
+      assert.strictEqual(unit('1 cup').to('floz').toString(), '8 floz')
+      assert.strictEqual(unit('1 cup').to('tablespoons').toString(), '16 tablespoons')
+      assert.strictEqual(unit('1 cup').to('teaspoons').toString(), '48 teaspoons')
+      assert.strictEqual(unit('1 cup').to('fluiddrams').toString(), '64 fluiddrams')
+    })
+  })
 })


### PR DESCRIPTION
This fixes the definition of a teaspoon and a fluid ounce to match the US customary fluid volume conversion tables found here:

https://en.wikipedia.org/wiki/Fluid_ounce
https://en.wikipedia.org/wiki/Cup_(unit)

I changed the definition of a fluid ounce to be based off cups so that the definition is in the same unit system.  If we still want it to be in mL, the value should be 29.5735295625 mL.  Looks like the value in master is actually in kiloliters.